### PR TITLE
[SRP-491] healthdata.nl link 'over de catalogus' refers to test version

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,12 +42,9 @@ const HomePage = () => {
             </p>
             <p className="mb-6 text-lg">
               Voor meer uitleg over deze catalogus, zie{" "}
-              <a
-                href="https://catalogus-test.healthdata.nl/about"
-                className="text-blue-500 hover:underline"
-              >
+              <Link href="/about" className="text-blue-500 hover:underline">
                 Over de catalogus
-              </a>
+              </Link>
             </p>
             <p className="mb-6 text-lg">
               Voor meer informatie over Health-RI, zie{" "}


### PR DESCRIPTION
See title. I fixed it using the react Link attribute so it'll always go to the correct version.