### PR TITLE
[SRP-565] show contactpoint and creator in frontend

### DIFF
--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -73,8 +73,12 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
     },
     {
       label: "Contact Point",
-      value: <p>{<a href={dataset.contact?.value}>dataset.contact?.label</a> || "No contact provided."}</p>
-      ,
+      value: createLinkItems(
+        dataset.contacts?.map((contact) => ({
+          label: contact.name ? contact.name : contact.uri,
+          url: contact.uri,
+        })),
+      ),
     },
     {
       label: "Access rights",

--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -45,9 +45,9 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
     {
       label: "Creator",
       value: createLinkItems(
-        dataset.creator?.map((creator) => ({
-          label: creator.label,
-          url: creator.value,
+        dataset.creators?.map((creators) => ({
+          label: creators.label,
+          url: creators.value,
         })),
       ),
     },
@@ -73,12 +73,8 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
     },
     {
       label: "Contact Point",
-      value: createLinkItems(
-        dataset.contact?.map((contact) => ({
-          label: contact.label,
-          url: contact.value,
-        })),
-      ),
+      value: <p>{<a href={dataset.contact?.value}>dataset.contact?.label</a> || "No contact provided."}</p>
+      ,
     },
     {
       label: "Access rights",

--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -43,6 +43,15 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
       value: createTextItem(dataset.publisherName),
     },
     {
+      label: "Creator",
+      value: createLinkItems(
+        dataset.creator?.map((creator) => ({
+          label: creator.label,
+          url: creator.value,
+        })),
+      ),
+    },
+    {
       label: "Identifier",
       value: createTextItem(dataset.identifier),
     },
@@ -63,11 +72,13 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
       ),
     },
     {
-      label: "Contact URI",
-      value: createLinkItem({
-        label: dataset.contact?.label,
-        url: dataset.contact?.value,
-      }),
+      label: "Contact Point",
+      value: createLinkItems(
+        dataset.contact?.map((contact) => ({
+          label: contact.label,
+          url: contact.value,
+        })),
+      ),
     },
     {
       label: "Access rights",

--- a/src/services/discovery/__tests__/datasetGet.test.ts
+++ b/src/services/discovery/__tests__/datasetGet.test.ts
@@ -39,10 +39,10 @@ describe('datasetGet', () => {
     expect(dataset.themes[0].label).toEqual('label');
     expect(dataset.themes[0].value).toEqual('value');
 
-    expect(dataset.contact[0].label).toEqual('Test Contact');
-    expect(dataset.contact[0].value).toEqual('mailto:test@example.com');
-    expect(dataset.creator[0].label).toEqual('label');
-    expect(dataset.creator[0].value).toEqual('value');
+    expect(dataset.contacts[0].name).toEqual('Test Contact');
+    expect(dataset.contacts[0].uri).toEqual('mailto:test@example.com');
+    expect(dataset.creators[0].label).toEqual('label');
+    expect(dataset.creators[0].value).toEqual('value');
 
     expect(dataset.publisherName).toEqual('Publisher');
     expect(dataset.catalogue).toEqual('Organization');

--- a/src/services/discovery/__tests__/datasetGet.test.ts
+++ b/src/services/discovery/__tests__/datasetGet.test.ts
@@ -39,6 +39,11 @@ describe('datasetGet', () => {
     expect(dataset.themes[0].label).toEqual('label');
     expect(dataset.themes[0].value).toEqual('value');
 
+    expect(dataset.contact[0].label).toEqual('Test Contact');
+    expect(dataset.contact[0].value).toEqual('mailto:test@example.com');
+    expect(dataset.creator[0].label).toEqual('label');
+    expect(dataset.creator[0].value).toEqual('value');
+
     expect(dataset.publisherName).toEqual('Publisher');
     expect(dataset.catalogue).toEqual('Organization');
     expect(dataset.provenance).toEqual('prov');

--- a/src/services/discovery/fixtures/datasetFixtures.ts
+++ b/src/services/discovery/fixtures/datasetFixtures.ts
@@ -13,6 +13,18 @@ export const retrivedDatasetFixture = {
       label: 'label',
     },
   ],
+  contact: [
+    {
+      label: 'Test Contact',
+      value: 'mailto:test@example.com',
+    },
+  ],
+  creator: [
+    {
+      label: 'label',
+      value: 'value',
+    },
+  ],
   publisherName: 'Publisher',
   catalogue: 'Organization',
   createdAt: '12-1-2023',

--- a/src/services/discovery/fixtures/datasetFixtures.ts
+++ b/src/services/discovery/fixtures/datasetFixtures.ts
@@ -13,13 +13,14 @@ export const retrivedDatasetFixture = {
       label: 'label',
     },
   ],
-  contact: [
+  contacts: [
     {
-      label: 'Test Contact',
-      value: 'mailto:test@example.com',
+      name: 'Test Contact',
+      uri: 'mailto:test@example.com',
+      email: 'test@example.com',
     },
   ],
-  creator: [
+  creators: [
     {
       label: 'label',
       value: 'value',

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -15,7 +15,7 @@ export interface RetrievedDataset {
   modifiedAt: string;
   url: string;
   languages: ValueLabel[];
-  contact: ValueLabel;
+  contacts: ContactPoint[];
   creators: ValueLabel[];
   hasVersions: ValueLabel[];
   accessRights: ValueLabel;
@@ -52,3 +52,9 @@ export interface RetrievedDistribution {
   createdAt: string;
   modifiedAt: string;
 }
+
+export type ContactPoint = {
+  name: string;
+  email: string;
+  uri: string;
+};

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -15,7 +15,8 @@ export interface RetrievedDataset {
   modifiedAt: string;
   url: string;
   languages: ValueLabel[];
-  contact: ValueLabel;
+  contact: ValueLabel[];
+  creator: ValueLabel[];
   hasVersions: ValueLabel[];
   accessRights: ValueLabel;
   conformsTo: ValueLabel[];

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -15,8 +15,8 @@ export interface RetrievedDataset {
   modifiedAt: string;
   url: string;
   languages: ValueLabel[];
-  contact: ValueLabel[];
-  creator: ValueLabel[];
+  contact: ValueLabel;
+  creators: ValueLabel[];
   hasVersions: ValueLabel[];
   accessRights: ValueLabel;
   conformsTo: ValueLabel[];


### PR DESCRIPTION
This PR adds contact point and creator to the front-end.

To test it: make sure you use the correct branch of dataset discovery service and latest version from trunk of the FDP harvester. Radboud FDP does not set these fields correctly yet either, so you'll have to fix it manually on the back-end.